### PR TITLE
Remove repository_auth_token parameter from self-hosted job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `repository_auth_token` parameter from `self-hosted` job
+
 ## [1.1.0] - 2020-10-31
 
 ### Added

--- a/src/examples/self-hosted.yml
+++ b/src/examples/self-hosted.yml
@@ -1,12 +1,6 @@
 description: |
   Run a self-hosted instance of Renovate.
 
-  Authentication:
-  1. Create a bot account for the Git repository.
-  2. Generate a Personal Access Token for the bot account.
-  3. In Project Settings, configure the RENOVATE_REPOSITORY_AUTH_TOKEN environment variable (or alternately the name of environment variable passed into the repository_auth_token parameter) as the generated Personal Access Token.
-  For more information, see: https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#user-content-authentication
-
   Configuration:
   1. Create a Renovate self-hosted configuration file (eg. renovate.config.js).
   2. Pass the file path into the config_file_path parameter.
@@ -15,6 +9,10 @@ description: |
   - https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#user-content-configuration
   - https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosted-configuration.md
   - https://docs.renovatebot.com/self-hosted-configuration
+
+  Secrets should be configured using environment variables (eg. RENOVATE_TOKEN, GITHUB_COM_TOKEN).
+
+  Configure environment variables in CircleCI Project Settings. To share environment variables across projects, use CircleCI Contexts (https://circleci.com/docs/2.0/contexts/).
 
   For more information and examples, see: https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md
 

--- a/src/jobs/self-hosted.yml
+++ b/src/jobs/self-hosted.yml
@@ -18,12 +18,6 @@ executor:
     "
 
 parameters:
-  repository_auth_token:
-    type: env_var_name
-    default: RENOVATE_REPOSITORY_AUTH_TOKEN
-    description: |
-      Environment variable name for the Git repository Personal Auth Token for the bot account.
-      See https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#user-content-authentication
   config_file_path:
     type: string
     default: config.js
@@ -43,4 +37,4 @@ steps:
   - checkout
   - run:
       name: Execute Renovate CLI
-      command: renovate --token ${<< parameters.repository_auth_token >>}
+      command: renovate


### PR DESCRIPTION
**SEMVER Update Type:**
- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Remove `repository_auth_token` parameter from `self-hosted` job.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

Environment variables are propagated to orb steps. The existing `RENOVATE_TOKEN` environment variable should be used instead.

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.