### PR TITLE
Add caching to self-hosted job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add caching to `self-hosted` job
+
 ## [2.0.0] - 2020-11-14
 
 ### Removed

--- a/src/jobs/self-hosted.yml
+++ b/src/jobs/self-hosted.yml
@@ -1,5 +1,7 @@
-description: >
+description: |
   Run a self-hosted instance of Renovate.
+
+  WARNING: Do not override cacheDir or RENOVATE_CACHE_DIR, or caching will be disabled, as this Orb does not support alternate cache directory locations as the moment.
 
 executor:
   name: default
@@ -18,6 +20,10 @@ executor:
     "
 
 parameters:
+  cache_version:
+    type: string
+    default: v1
+    description: Change the default cache version if you need to clear the cache for any reason.
   config_file_path:
     type: string
     default: config.js
@@ -32,9 +38,28 @@ parameters:
     description: |
       Use "slim" Docker images to reduce startup time.
       Set to true if you only use package managers that don't need third party binaries (e.g. JS, Docker, Nuget, pip).
+  with_cache:
+    type: boolean
+    default: true
+    description: Share Renovate cache between runs.
 
 steps:
+  - when:
+      condition: << parameters.with_cache >>
+      steps:
+        - restore_cache:
+            name: Restore Renovate cache
+            keys:
+              - renovate-<< parameters.cache_version >>-
   - checkout
   - run:
       name: Execute Renovate CLI
       command: renovate
+  - when:
+      condition: << parameters.with_cache >>
+      steps:
+        - save_cache:
+            name: Save YARN package cache
+            key: renovate-<< parameters.cache_version >>-{{ epoch }}
+            paths:
+              - /tmp/renovate/cache # TODO: Use $RENOVATE_CACHE_DIR when CircleCI supports environment variables in save_cache.paths


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Cache Renovate's cache directory (`/tmp/renovate/cache`) between runs.

Unfortunately, because `save_cache.paths` cannot be parameterized, the [cacheDir](https://docs.renovatebot.com/self-hosted-configuration/#cachedir) cannot be overridden for the Orb's caching to work.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

Improve performance of repeated `self-hosted` job execution.

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.