### PR TITLE
Automatically republish dev:alpha orb every month

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,3 +79,19 @@ workflows:
               only:
                 - master
                 - main
+
+  # Republish the dev:alpha orb every month to ensure new pipelines don't get rejected due to expired dev orbs.
+  keep-dev-orb:
+    triggers:
+      - schedule:
+          cron: "0 0 1 * *"
+          filters:
+            branches:
+              only:
+                - master
+                - main
+    jobs:
+      - orb-tools/publish-dev:
+          orb-name: daniel-shuy/renovate
+          context: orb-publishing
+          publish-sha-version: false


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [ ] Patch

## Description:

Prevent `dev:alpha` orb from expiring (expires after 90 days).

Implementation copied from secrethub/secrethub-circleci-orb#39

## Motivation:

`dev:alpha` orb is used for integration tests. The build will fail if the `dev:alpha` orb has expired.

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.