### PR TITLE
Move self-hosted configuration file validation to a new validate-self-hosted-config job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ### Changed
 
-- Move self-hosted configuration file validation to a new `validate-self-hosted-config` job
+- Move self-hosted configuration file validation to a new
+  `validate-self-hosted-config` job
 
 ## [2.2.0] - 2021-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Move self-hosted configuration file validation to a new `validate-self-hosted-config` job
+
 ## [2.2.0] - 2021-06-15
 
 ### Changed

--- a/src/examples/validate-self-hosted-config.yml
+++ b/src/examples/validate-self-hosted-config.yml
@@ -1,8 +1,9 @@
 description: |
-  Validate Renovate configuration file and self-hosted configuration file.
+  Validate Renovate self-hosted configuration file.
 
-  Configuration file definition: https://docs.renovatebot.com/configuration-options/
   Self-hosted configuration file docs: https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#user-content-configuration
+
+  Override self_hosted_config_file_path if the self-hosted configuration file is not at the default path (config.js).
 
 usage:
   version: 2.1
@@ -11,5 +12,6 @@ usage:
   workflows:
     lint:
       jobs:
-        - renovate/validate-config:
+        - renovate/validate-self-hosted-config:
+            renovate_version: $RENOVATE_VERSION
             self_hosted_config_file_path: renovate.config.js

--- a/src/jobs/validate-self-hosted-config.yml
+++ b/src/jobs/validate-self-hosted-config.yml
@@ -1,7 +1,7 @@
 description: >
-  Validate Renovate configuration file.
+  Validate Renovate self-hosted configuration file.
 
-  Configuration file definition: https://docs.renovatebot.com/configuration-options/
+  Self-hosted configuration file docs: https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#user-content-configuration
 
 executor:
   name: default
@@ -19,15 +19,20 @@ resource_class: <<parameters.resource_class>>
 parameters:
   renovate_version:
     type: string
-    default: ""
-    description: Override this with the Renovate version if you are using a self-hosted instance of Renovate, else leave it empty.
+    description: The version of your self-hosted instance of Renovate.
   resource_class:
     type: string
     default: medium
     description: Amount of CPU and RAM allocated to each container in a job.
+  self_hosted_config_file_path:
+    type: string
+    default: config.js
+    description: Path to self-hosted configuration file.
 
 steps:
   - checkout
   - run:
-      name: Validate Renovate config
+      name: Validate Renovate self-hosted config
       command: renovate-config-validator
+      environment:
+        RENOVATE_CONFIG_FILE: << parameters.self_hosted_config_file_path >>


### PR DESCRIPTION
**SEMVER Update Type:**
- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

Since Renovate `26.11.0`, `renovate-config-validator` throws an error if `RENOVATE_CONFIG_FILE` is defined but the file is not found (see renovatebot/renovate#11462).

The `validate-config` job sets the `RENOVATE_CONFIG_FILE` environment variable to the `self_hosted_config_file_path` argument.
Since `self_hosted_config_file_path` has a default value, `RENOVATE_CONFIG_FILE` will always be set even if not intending to validate a self-hosted configuration file, which results in an error if a self-hosted configuration file doesn't exist at that path.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  #19

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Changelog has been updated.